### PR TITLE
Add head and base fields of pull request hook info

### DIFF
--- a/src/GitHub/Data/Webhooks/Events.hs
+++ b/src/GitHub/Data/Webhooks/Events.hs
@@ -94,7 +94,7 @@ module GitHub.Data.Webhooks.Events
     , WatchEventAction(..)
     ) where
 
-import           Data.Aeson               (FromJSON(..), withObject, withText, (.:), (.:?), Object)
+import           Data.Aeson               (FromJSON(..), withObject, withText, (.:), (.:?))
 import           Control.DeepSeq          (NFData(..))
 import           Control.DeepSeq.Generics (genericRnf)
 import           Data.Data                (Data, Typeable)
@@ -854,7 +854,6 @@ data PullRequestEvent = PullRequestEvent
     , evPullReqRepo             :: !HookRepository
     , evPullReqSender           :: !HookUser
     , evPullReqInstallationId   :: !Int
-    , evRawObject               :: !Object
     }
     deriving (Eq, Show, Typeable, Data, Generic)
 
@@ -1352,7 +1351,6 @@ instance FromJSON PullRequestEvent where
         <*> o .: "repository"
         <*> o .: "sender"
         <*> (o .: "installation" >>= \i -> i .: "id")
-        <*> pure o
 
 instance FromJSON PullRequestReviewEvent where
     parseJSON = withObject "PullRequestReviewEvent" $ \o -> PullRequestReviewEvent

--- a/src/GitHub/Data/Webhooks/Payload.hs
+++ b/src/GitHub/Data/Webhooks/Payload.hs
@@ -426,9 +426,6 @@ data HookRelease = HookRelease
 
 instance NFData HookRelease where rnf = genericRnf
 
-
--- FIXME: Property "head" missing (not sure)
--- FIXME: Property "base" missing (not sure)
 data HookPullRequest = HookPullRequest
     { whPullReqUrl              :: !URL
     , whPullReqId               :: !Int


### PR DESCRIPTION
Pull request events were dropping perhaps the most critical information: the source and destination of the request.  With this patch we are now capturing the source and destination information (i.e. repository, hash, branch name).