### PR TITLE
Make `PullRequestEvent`'s installation field optional.

### DIFF
--- a/spec/DecodeEventsSpec.hs
+++ b/spec/DecodeEventsSpec.hs
@@ -3033,7 +3033,7 @@ pullRequestEventFixture = PullRequestEvent
           , whUserType = OwnerUser
           , whUserIsAdminOfSite = False
           }
-    , evPullReqInstallationId = 234
+    , evPullReqInstallationId = Just 234
     }
 
 pullRequestReviewCommentEventFixture :: PullRequestReviewCommentEvent

--- a/src/GitHub/Data/Webhooks/Events.hs
+++ b/src/GitHub/Data/Webhooks/Events.hs
@@ -1360,7 +1360,7 @@ instance FromJSON PullRequestEvent where
         <*> o .: "pull_request"
         <*> o .: "repository"
         <*> o .: "sender"
-        <*> (o .: "installation" >>= \i -> i .: "id")
+        <*> (o .:? "installation" >>= maybe (pure Nothing) (.:? "id"))
 
 instance FromJSON PullRequestReviewEvent where
     parseJSON = withObject "PullRequestReviewEvent" $ \o -> PullRequestReviewEvent

--- a/src/GitHub/Data/Webhooks/Events.hs
+++ b/src/GitHub/Data/Webhooks/Events.hs
@@ -863,7 +863,7 @@ data PullRequestEvent = PullRequestEvent
     , evPullReqPayload          :: !HookPullRequest
     , evPullReqRepo             :: !HookRepository
     , evPullReqSender           :: !HookUser
-    , evPullReqInstallationId   :: !Int
+    , evPullReqInstallationId   :: !(Maybe Int)
     }
     deriving (Eq, Show, Typeable, Data, Generic)
 


### PR DESCRIPTION
Going by the [github docs](https://developer.github.com/webhooks/#payloads) this field appears to be optional.

```
a GitHub App's webhook may include the installation (installation) which
an event relates to.
```

I can safely say that I definitely have been receiving webhook events that do not contain an installation field.