### PR TITLE
Handle when issue.body is `null`

### DIFF
--- a/src/GitHub/Data/Webhooks/Payload.hs
+++ b/src/GitHub/Data/Webhooks/Payload.hs
@@ -950,7 +950,7 @@ instance FromJSON HookIssue where
       <*> o .: "created_at"
       <*> o .: "updated_at"
       <*> o .:? "closed_at"
-      <*> o .: "body"
+      <*> o .:? "body" .!= ""
 
 instance FromJSON HookRepository where
   parseJSON = withObject "HookRepository" $ \o -> HookRepository


### PR DESCRIPTION
Handle parsing the case where issue.body is `null`. Make the field be
optional but default to an empty string

**Issue reference:**
<!-- Which issue(s) does this solve? Do you need to make one? -->

**Submission Checklist:**
* [x] Have you followed the guidelines in our [Contributing](../../CONTRIBUTING.md) document (for example, is your tree a clean merge)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Does your submission build?
* [ ] Does your submission pass tests?
* [ ] Have you run lints on your code locally prior to submission?
* [ ] Have you updated *all* of the cabal/nix infrastructure?
* [ ] Is this a breaking change? Have you discussed this?

<!-- Please tag a maintainer if you don't get a response within a reasonable period of time -->
