### PR TITLE
[#56]: CheckSuite after field can be null

### DIFF
--- a/spec/DecodeEventsSpec.hs
+++ b/spec/DecodeEventsSpec.hs
@@ -94,7 +94,7 @@ checkSuiteEventFixture = CheckSuiteEvent
           , whCheckSuiteConclusion = Just HookCheckSuiteConclusionActionRequired
           , whCheckSuiteUrl = URL "https://api.github.com/repos/baxterthehacker/public-repo/check-suites/123451234"
           , whCheckSuiteBeforeSha = Just "15c99c3e0b9d840d8465be47813cf39686815f2e"
-          , whCheckSuiteAfterSha = "45deaf5013c757e58e2665849c3fd3add3edfa59"
+          , whCheckSuiteAfterSha = Just "45deaf5013c757e58e2665849c3fd3add3edfa59"
           , whCheckSuitePullRequests =
               V.fromList [
                 HookChecksPullRequest
@@ -315,7 +315,7 @@ checkRunEventFixture = CheckRunEvent
                 , whCheckSuiteConclusion = Nothing
                 , whCheckSuiteUrl = URL "https://api.github.com/repos/baxterthehacker/public-repo/check-suites/123451234"
                 , whCheckSuiteBeforeSha = Just "15c99c3e0b9d840d8465be47813cf39686815f2e"
-                , whCheckSuiteAfterSha = "45deaf5013c757e58e2665849c3fd3add3edfa59"
+                , whCheckSuiteAfterSha = Just "45deaf5013c757e58e2665849c3fd3add3edfa59"
                 , whCheckSuitePullRequests =
                     V.fromList [
                       HookChecksPullRequest

--- a/src/GitHub/Data/Webhooks/Payload.hs
+++ b/src/GitHub/Data/Webhooks/Payload.hs
@@ -601,7 +601,7 @@ data HookCheckSuite = HookCheckSuite
     , whCheckSuiteConclusion           :: !(Maybe HookCheckSuiteConclusion)
     , whCheckSuiteUrl                  :: !URL
     , whCheckSuiteBeforeSha            :: !(Maybe Text)
-    , whCheckSuiteAfterSha             :: !Text
+    , whCheckSuiteAfterSha             :: !(Maybe Text)
     , whCheckSuitePullRequests         :: !(Vector HookChecksPullRequest)
     , whCheckSuiteCreatedAt            :: !UTCTime
     , whCheckSuiteUpdatedAt            :: !UTCTime
@@ -1310,7 +1310,7 @@ instance FromJSON HookCheckSuite where
       <*> o .:? "conclusion"
       <*> o .: "url"
       <*> o .:? "before"
-      <*> o .: "after"
+      <*> o .:? "after"
       <*> o .: "pull_requests"
       <*> o .: "created_at"
       <*> o .: "updated_at"


### PR DESCRIPTION
**Issue reference:** Pretty trivial, do I need one?
<!-- Which issue(s) does this solve? Do you need to make one? -->

I just noticed there are cases where the check suite after field is null.

**Submission Checklist:**
* [x] Have you followed the guidelines in our [Contributing](../../CONTRIBUTING.md) document (for example, is your tree a clean merge)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Does your submission build?
* [x] Does your submission pass tests?
* [x] Have you run lints on your code locally prior to submission?
* [x] Have you updated *all* of the cabal/nix infrastructure?
* [x] Is this a breaking change? Have you discussed this?

<!-- Please tag a maintainer if you don't get a response within a reasonable period of time -->
