### PR TITLE
[#75]: Add missing draft field to HookPullRequest

### DIFF
--- a/spec/DecodeEventsSpec.hs
+++ b/spec/DecodeEventsSpec.hs
@@ -3785,6 +3785,7 @@ pullRequestEventFixture = PullRequestEvent
                 , whPullReqTargetLabel = "baxterthehacker:changes"
                 , whPullReqTargetRef = "changes"
                 }
+          , whPullReqIsDraft = Nothing
           , whPullReqMergeableState = Just "unknown"
           , whPullReqCommentCount = Just 0
           , whPullReqRevCommentCount = Just 0
@@ -4188,6 +4189,7 @@ pullRequestEventNullBodyFixture = PullRequestEvent
                 , whPullReqTargetLabel = "baxterthehacker:changes"
                 , whPullReqTargetRef = "changes"
                 }
+          , whPullReqIsDraft = Nothing
           , whPullReqMergeableState = Just "unknown"
           , whPullReqCommentCount = Just 0
           , whPullReqRevCommentCount = Just 0
@@ -4507,6 +4509,7 @@ pullRequestEventDeleteNullHeadRepoAnomalyFixture =
                   whPullReqTargetLabel = "thecontributor:master",
                   whPullReqTargetRef = "master"
                 },
+            whPullReqIsDraft = Just False,
             whPullReqMergeableState = Just "dirty",
             whPullReqCommentCount = Just 2,
             whPullReqRevCommentCount = Just 0,
@@ -4957,6 +4960,7 @@ pullRequestReviewCommentEventFixture = PullRequestReviewCommentEvent
                 , whPullReqTargetLabel = "baxterthehacker:changes"
                 , whPullReqTargetRef = "changes"
                 }
+          , whPullReqIsDraft = Nothing
           , whPullReqMergeableState = Nothing
           }
     , evPullReqRevRepo =
@@ -5384,6 +5388,7 @@ pullRequestReviewEventFixture = PullRequestReviewEvent
               , whPullReqTargetLabel = "skalnik:patch-2"
               , whPullReqTargetRef = "patch-2"
               }
+        , whPullReqIsDraft = Nothing
         , whPullReqMergeableState = Nothing
         , whPullReqCommentCount = Nothing
         , whPullReqRevCommentCount = Nothing

--- a/src/GitHub/Data/Webhooks/Payload.hs
+++ b/src/GitHub/Data/Webhooks/Payload.hs
@@ -836,6 +836,7 @@ data HookPullRequest = HookPullRequest
     , whPullReqStatusesUrl      :: !URL
     , whPullReqBase             :: !PullRequestTarget
     , whPullReqHead             :: !PullRequestTarget
+    , whPullReqIsDraft          :: !(Maybe Bool)
     -- , whPullReqIsMerged         :: !Bool
     -- , whPullReqIsMergeable      :: !Bool
     , whPullReqMergeableState   :: !(Maybe Text)              -- ^ Not sent with all events.
@@ -1437,6 +1438,7 @@ instance FromJSON HookPullRequest where
       <*> o .: "statuses_url"
       <*> o .: "base"
       <*> o .: "head"
+      <*> o .:? "draft"
       -- <*> o .: "merged"
       -- <*> o .: "mergeable"
       <*> o .:? "mergeable_state"


### PR DESCRIPTION
**Issue reference:**

I didn't open an issue as this seemed simple enough.

**Submission Checklist:**
* [x] Have you followed the guidelines in our [Contributing](../../CONTRIBUTING.md) document (for example, is your tree a clean merge)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Does your submission build?
* [x] Does your submission pass tests?
* [x] Have you run lints on your code locally prior to submission?
* ~~Have you updated *all* of the cabal/nix infrastructure?~~
* [ ] Is this a breaking change? Have you discussed this?
  * → Is it? I'm very new to Haskell. I suppose it does break instantiations so that they now result in a missing field error.

<!-- Please tag a maintainer if you don't get a response within a reasonable period of time -->
