### PR TITLE
Add missing app field to HookCheckSuite

### DIFF
--- a/spec/DecodeEventsSpec.hs
+++ b/spec/DecodeEventsSpec.hs
@@ -147,6 +147,78 @@ checkSuiteEventFixture = CheckSuiteEvent
                         , whSimplUserLogin = Nothing
                         }
                   }
+          , whCheckSuiteApp =
+              Just HookCheckSuiteApp
+                { whCheckSuiteAppId = 12345
+                , whCheckSuiteAppNodeId = "MDg6Q2hlY2tSdW4xMjg2MjAyMjg="
+                , whCheckSuiteAppClientId = Nothing
+                , whCheckSuiteAppSlug = Just "baxterandthehackers-app"
+                , whCheckSuiteAppOwner =
+                    HookUser
+                    { whUserLogin = "baxterthehacker"
+                    , whUserId = 12341234
+                    , whUserNodeId= "MDg6Q2hlY2tSdW4xMjg2MjAyMjg="
+                    , whUserAvatarUrl = URL "https://avatars2.githubusercontent.com/u/60385638?v=4"
+                    , whUserGravatarId = URL ""
+                    , whUserUrl = URL "https://api.github.com/users/baxterthehacker"
+                    , whUserHtmlUrl = URL "https://github.com/baxterthehacker"
+                    , whUserFollowersUrl = URL "https://api.github.com/users/baxterthehacker/followers"
+                    , whUserFollowingUrl = URL "https://api.github.com/users/baxterthehacker/following{/other_user}"
+                    , whUserGistsUrl = URL "https://api.github.com/users/baxterthehacker/gists{/gist_id}"
+                    , whUserStarredUrl = URL "https://api.github.com/users/baxterthehacker/starred{/owner}{/repo}"
+                    , whUserSubscriptionsUrl = URL "https://api.github.com/users/baxterthehacker/subscriptions"
+                    , whUserOrganizationsUrl = URL "https://api.github.com/users/baxterthehacker/orgs"
+                    , whUserReposUrl = URL "https://api.github.com/users/baxterthehacker/repos"
+                    , whUserEventsUrl = URL "https://api.github.com/users/baxterthehacker/events{/privacy}"
+                    , whUserReceivedEventsUrl = URL "https://api.github.com/users/baxterthehacker/received_events"
+                    , whUserType = OwnerOrganization
+                    , whUserIsAdminOfSite = False
+                    }
+                , whCheckSuiteAppName = "Baxterandthehackers App"
+                , whCheckSuiteAppDescription = ""
+                , whCheckSuiteAppExternalUrl = URL "https://www.baxterthehacker.com"
+                , whCheckSuiteAppHtmlUrl = URL "https://github.com/apps/baxterandthehackers-app"
+                , whCheckSuiteAppCreatedAt = read "2020-01-19 07:05:42Z"
+                , whCheckSuiteAppUpdatedAt = read "2020-02-18 00:24:52Z"
+                , whCheckSuiteAppEvents = Just (V.fromList ["check_run", "check_suite"])
+                , whCheckSuiteAppPermissions = Just HookCheckSuiteAppPermissions
+                  { whCheckSuiteAppPermissionsChecks = Just "write"
+                  , whCheckSuiteAppPermissionsIssues = Just "read"
+                  , whCheckSuiteAppPermissionsMetadata = Just "read"
+                  , whCheckSuiteAppPermissionsContents = Nothing
+                  , whCheckSuiteAppPermissionsDeployments = Nothing
+                  , whCheckSuiteAppPermissionsActions = Nothing
+                  , whCheckSuiteAppPermissionsAdministration = Nothing
+                  , whCheckSuiteAppPermissionsContentReferences = Nothing
+                  , whCheckSuiteAppPermissionsDiscussions = Nothing
+                  , whCheckSuiteAppPermissionsEmails = Nothing
+                  , whCheckSuiteAppPermissionsEnvironments = Nothing
+                  , whCheckSuiteAppPermissionsKeys = Nothing
+                  , whCheckSuiteAppPermissionsMembers = Nothing
+                  , whCheckSuiteAppPermissionsOrganizationAdministration = Nothing
+                  , whCheckSuiteAppPermissionsOrganizationHooks = Nothing
+                  , whCheckSuiteAppPermissionsOrganisationPackages = Nothing
+                  , whCheckSuiteAppPermissionsOrganizationPlan = Nothing
+                  , whCheckSuiteAppPermissionsOrganizationProjects = Nothing
+                  , whCheckSuiteAppPermissionsOrganizationSecrets = Nothing
+                  , whCheckSuiteAppPermissionsOrganizationSelfHostedRunners = Nothing
+                  , whCheckSuiteAppPermissionsOrganizationUserBlocking = Nothing
+                  , whCheckSuiteAppPermissionsPackages = Nothing
+                  , whCheckSuiteAppPermissionsPages = Nothing
+                  , whCheckSuiteAppPermissionsPullRequests = Nothing
+                  , whCheckSuiteAppPermissionsRepositoryHooks = Nothing
+                  , whCheckSuiteAppPermissionsRepositoryProjects = Nothing
+                  , whCheckSuiteAppPermissionsSecretScanningAlerts = Nothing
+                  , whCheckSuiteAppPermissionsSecrets = Nothing
+                  , whCheckSuiteAppPermissionsSecurityEvents = Nothing
+                  , whCheckSuiteAppPermissionsSecurityScanningAlert = Nothing
+                  , whCheckSuiteAppPermissionsSingleFile = Nothing
+                  , whCheckSuiteAppPermissionsStatuses = Nothing
+                  , whCheckSuiteAppPermissionsTeamDiscussion = Nothing
+                  , whCheckSuiteAppPermissionsVulnerabilityAlerts = Nothing
+                  , whCheckSuiteAppPermissionsWorkflows = Nothing
+                  }
+                }
           }
     , evCheckSuiteRepository =
         HookRepository
@@ -352,6 +424,78 @@ checkRunEventFixture = CheckRunEvent
                 , whCheckSuiteLatestCheckRunsCount = Nothing
                 , whCheckSuiteCheckRunsUrl = Nothing
                 , whCheckSuiteHeadCommit = Nothing
+                , whCheckSuiteApp =
+                    Just HookCheckSuiteApp
+                      { whCheckSuiteAppId = 12345
+                      , whCheckSuiteAppClientId = Nothing
+                      , whCheckSuiteAppNodeId = "MDg6Q2hlY2tSdW4xMjg2MjAyMjg="
+                      , whCheckSuiteAppSlug = Just "baxterandthehackers-app"
+                      , whCheckSuiteAppOwner =
+                          HookUser
+                          { whUserLogin = "baxterthehacker"
+                          , whUserId = 12341234
+                          , whUserNodeId= "MDg6Q2hlY2tSdW4xMjg2MjAyMjg="
+                          , whUserAvatarUrl = URL "https://avatars2.githubusercontent.com/u/60385638?v=4"
+                          , whUserGravatarId = URL ""
+                          , whUserUrl = URL "https://api.github.com/users/baxterthehacker"
+                          , whUserHtmlUrl = URL "https://github.com/baxterthehacker"
+                          , whUserFollowersUrl = URL "https://api.github.com/users/baxterthehacker/followers"
+                          , whUserFollowingUrl = URL "https://api.github.com/users/baxterthehacker/following{/other_user}"
+                          , whUserGistsUrl = URL "https://api.github.com/users/baxterthehacker/gists{/gist_id}"
+                          , whUserStarredUrl = URL "https://api.github.com/users/baxterthehacker/starred{/owner}{/repo}"
+                          , whUserSubscriptionsUrl = URL "https://api.github.com/users/baxterthehacker/subscriptions"
+                          , whUserOrganizationsUrl = URL "https://api.github.com/users/baxterthehacker/orgs"
+                          , whUserReposUrl = URL "https://api.github.com/users/baxterthehacker/repos"
+                          , whUserEventsUrl = URL "https://api.github.com/users/baxterthehacker/events{/privacy}"
+                          , whUserReceivedEventsUrl = URL "https://api.github.com/users/baxterthehacker/received_events"
+                          , whUserType = OwnerOrganization
+                          , whUserIsAdminOfSite = False
+                          }
+                      , whCheckSuiteAppName = "Baxterandthehackers App"
+                      , whCheckSuiteAppDescription = ""
+                      , whCheckSuiteAppExternalUrl = URL "https://www.baxterthehacker.com"
+                      , whCheckSuiteAppHtmlUrl = URL "https://github.com/apps/baxterandthehackers-app"
+                      , whCheckSuiteAppCreatedAt = read "2020-01-19 07:05:42Z"
+                      , whCheckSuiteAppUpdatedAt = read "2020-02-18 00:24:52Z"
+                      , whCheckSuiteAppPermissions = Just HookCheckSuiteAppPermissions
+                        { whCheckSuiteAppPermissionsChecks = Just "write"
+                        , whCheckSuiteAppPermissionsIssues = Just "read"
+                        , whCheckSuiteAppPermissionsMetadata = Just "read"
+                        , whCheckSuiteAppPermissionsContents = Nothing
+                        , whCheckSuiteAppPermissionsDeployments = Nothing
+                        , whCheckSuiteAppPermissionsActions = Nothing
+                        , whCheckSuiteAppPermissionsAdministration = Nothing
+                        , whCheckSuiteAppPermissionsContentReferences = Nothing
+                        , whCheckSuiteAppPermissionsDiscussions = Nothing
+                        , whCheckSuiteAppPermissionsEmails = Nothing
+                        , whCheckSuiteAppPermissionsEnvironments = Nothing
+                        , whCheckSuiteAppPermissionsKeys = Nothing
+                        , whCheckSuiteAppPermissionsMembers = Nothing
+                        , whCheckSuiteAppPermissionsOrganizationAdministration = Nothing
+                        , whCheckSuiteAppPermissionsOrganizationHooks = Nothing
+                        , whCheckSuiteAppPermissionsOrganisationPackages = Nothing
+                        , whCheckSuiteAppPermissionsOrganizationPlan = Nothing
+                        , whCheckSuiteAppPermissionsOrganizationProjects = Nothing
+                        , whCheckSuiteAppPermissionsOrganizationSecrets = Nothing
+                        , whCheckSuiteAppPermissionsOrganizationSelfHostedRunners = Nothing
+                        , whCheckSuiteAppPermissionsOrganizationUserBlocking = Nothing
+                        , whCheckSuiteAppPermissionsPackages = Nothing
+                        , whCheckSuiteAppPermissionsPages = Nothing
+                        , whCheckSuiteAppPermissionsPullRequests = Nothing
+                        , whCheckSuiteAppPermissionsRepositoryHooks = Nothing
+                        , whCheckSuiteAppPermissionsRepositoryProjects = Nothing
+                        , whCheckSuiteAppPermissionsSecretScanningAlerts = Nothing
+                        , whCheckSuiteAppPermissionsSecrets = Nothing
+                        , whCheckSuiteAppPermissionsSecurityEvents = Nothing
+                        , whCheckSuiteAppPermissionsSecurityScanningAlert = Nothing
+                        , whCheckSuiteAppPermissionsSingleFile = Nothing
+                        , whCheckSuiteAppPermissionsStatuses = Nothing
+                        , whCheckSuiteAppPermissionsTeamDiscussion = Nothing
+                        , whCheckSuiteAppPermissionsVulnerabilityAlerts = Nothing
+                        , whCheckSuiteAppPermissionsWorkflows = Nothing
+                        }
+                      , whCheckSuiteAppEvents = Just (V.fromList ["check_run", "check_suite"])
+                      }
                 }
           , whCheckRunPullRequests =
               V.fromList [

--- a/src/GitHub/Data/Webhooks/Payload.hs
+++ b/src/GitHub/Data/Webhooks/Payload.hs
@@ -39,6 +39,8 @@ module GitHub.Data.Webhooks.Payload
     , HookCheckSuiteConclusion(..)
     , HookCheckSuite(..)
     , HookCheckSuiteCommit(..)
+    , HookCheckSuiteApp(..)
+    , HookCheckSuiteAppPermissions(..)
     , HookCheckRunStatus(..)
     , HookCheckRunConclusion(..)
     , HookCheckRun(..)
@@ -608,6 +610,7 @@ data HookCheckSuite = HookCheckSuite
     , whCheckSuiteLatestCheckRunsCount :: !(Maybe Int) -- not included in the check run nested payload
     , whCheckSuiteCheckRunsUrl         :: !(Maybe URL) -- not included in the check run nested payload
     , whCheckSuiteHeadCommit           :: !(Maybe HookCheckSuiteCommit) -- not included in the check run nested payload
+    , whCheckSuiteApp                  :: !(Maybe HookCheckSuiteApp) -- not included in the check run nested payload
     }
     deriving (Eq, Show, Typeable, Data, Generic)
 
@@ -623,6 +626,68 @@ data HookCheckSuiteCommit = HookCheckSuiteCommit
     deriving (Eq, Show, Typeable, Data, Generic)
 
 instance NFData HookCheckSuiteCommit where rnf = genericRnf
+
+-- | Represents the "app" field in the
+--  'CheckSuiteEvent' payload.
+data HookCheckSuiteApp = HookCheckSuiteApp
+    { whCheckSuiteAppId          :: !Int
+    , whCheckSuiteAppNodeId      :: !Text
+    , whCheckSuiteAppSlug        :: !(Maybe Text)
+    , whCheckSuiteAppOwner       :: !HookUser
+    , whCheckSuiteAppName        :: !Text
+    , whCheckSuiteAppDescription :: !Text
+    , whCheckSuiteAppExternalUrl :: !URL
+    , whCheckSuiteAppHtmlUrl     :: !URL
+    , whCheckSuiteAppClientId    :: !(Maybe Text)
+    , whCheckSuiteAppCreatedAt   :: !UTCTime
+    , whCheckSuiteAppUpdatedAt   :: !UTCTime
+    , whCheckSuiteAppPermissions :: !(Maybe HookCheckSuiteAppPermissions)
+    , whCheckSuiteAppEvents      :: !(Maybe (Vector Text))
+    }
+    deriving (Eq, Show, Typeable, Data, Generic)
+
+instance NFData HookCheckSuiteApp where rnf = genericRnf
+
+data HookCheckSuiteAppPermissions = HookCheckSuiteAppPermissions
+    { whCheckSuiteAppPermissionsActions                       :: !(Maybe Text)
+    , whCheckSuiteAppPermissionsAdministration                :: !(Maybe Text)
+    , whCheckSuiteAppPermissionsChecks                        :: !(Maybe Text)
+    , whCheckSuiteAppPermissionsContentReferences             :: !(Maybe Text)
+    , whCheckSuiteAppPermissionsContents                      :: !(Maybe Text)
+    , whCheckSuiteAppPermissionsDeployments                   :: !(Maybe Text)
+    , whCheckSuiteAppPermissionsDiscussions                   :: !(Maybe Text)
+    , whCheckSuiteAppPermissionsEmails                        :: !(Maybe Text)
+    , whCheckSuiteAppPermissionsEnvironments                  :: !(Maybe Text)
+    , whCheckSuiteAppPermissionsIssues                        :: !(Maybe Text)
+    , whCheckSuiteAppPermissionsKeys                          :: !(Maybe Text)
+    , whCheckSuiteAppPermissionsMembers                       :: !(Maybe Text)
+    , whCheckSuiteAppPermissionsMetadata                      :: !(Maybe Text)
+    , whCheckSuiteAppPermissionsOrganizationAdministration    :: !(Maybe Text)
+    , whCheckSuiteAppPermissionsOrganizationHooks             :: !(Maybe Text)
+    , whCheckSuiteAppPermissionsOrganisationPackages          :: !(Maybe Text)
+    , whCheckSuiteAppPermissionsOrganizationPlan              :: !(Maybe Text)
+    , whCheckSuiteAppPermissionsOrganizationProjects          :: !(Maybe Text)
+    , whCheckSuiteAppPermissionsOrganizationSecrets           :: !(Maybe Text)
+    , whCheckSuiteAppPermissionsOrganizationSelfHostedRunners :: !(Maybe Text)
+    , whCheckSuiteAppPermissionsOrganizationUserBlocking      :: !(Maybe Text)
+    , whCheckSuiteAppPermissionsPackages                      :: !(Maybe Text)
+    , whCheckSuiteAppPermissionsPages                         :: !(Maybe Text)
+    , whCheckSuiteAppPermissionsPullRequests                  :: !(Maybe Text)
+    , whCheckSuiteAppPermissionsRepositoryHooks               :: !(Maybe Text)
+    , whCheckSuiteAppPermissionsRepositoryProjects            :: !(Maybe Text)
+    , whCheckSuiteAppPermissionsSecretScanningAlerts          :: !(Maybe Text)
+    , whCheckSuiteAppPermissionsSecrets                       :: !(Maybe Text)
+    , whCheckSuiteAppPermissionsSecurityEvents                :: !(Maybe Text)
+    , whCheckSuiteAppPermissionsSecurityScanningAlert         :: !(Maybe Text)
+    , whCheckSuiteAppPermissionsSingleFile                    :: !(Maybe Text)
+    , whCheckSuiteAppPermissionsStatuses                      :: !(Maybe Text)
+    , whCheckSuiteAppPermissionsTeamDiscussion                :: !(Maybe Text)
+    , whCheckSuiteAppPermissionsVulnerabilityAlerts           :: !(Maybe Text)
+    , whCheckSuiteAppPermissionsWorkflows                     :: !(Maybe Text)
+    }
+    deriving (Eq, Show, Typeable, Data, Generic)
+
+instance NFData HookCheckSuiteAppPermissions where rnf = genericRnf
 
 -- | Represents the "status" field in the
 --  'HookCheckRun' payload.
@@ -682,7 +747,6 @@ instance FromJSON HookCheckRunConclusion where
           "stale"                 -> pure HookCheckRunConclusionStale
           _                       -> pure (HookCheckRunConclusionOther t)
 
--- FIXME: Missing nested "app", there are examples, but no documentation.
 -- | Represents the "check_run" field in the
 --  'CheckRunEvent' payload.
 data HookCheckRun = HookCheckRun
@@ -1318,12 +1382,67 @@ instance FromJSON HookCheckSuite where
       <*> o .:? "latest_check_runs_count"
       <*> o .:? "check_runs_url"
       <*> o .:? "head_commit"
+      <*> o .:? "app"
 
 instance FromJSON HookCheckSuiteCommit where
   parseJSON = withObject "HookCheckSuiteCommit" $ \o -> HookCheckSuiteCommit
       <$> o .: "id"
       <*> o .: "author"
       <*> o .: "committer"
+
+instance FromJSON HookCheckSuiteApp where
+  parseJSON = withObject "HookCheckSuiteApp" $ \o -> HookCheckSuiteApp
+      <$> o .: "id"
+      <*> o .: "node_id"
+      <*> o .:? "slug"
+      <*> o .: "owner"
+      <*> o .: "name"
+      <*> o .: "description"
+      <*> o .: "external_url"
+      <*> o .: "html_url"
+      <*> o .:? "client_id"
+      <*> o .: "created_at"
+      <*> o .: "updated_at"
+      <*> o .:? "permissions"
+      <*> o .:? "events"
+
+instance FromJSON HookCheckSuiteAppPermissions where
+  parseJSON = withObject "HookCheckSuiteAppPermissions" $ \o -> HookCheckSuiteAppPermissions
+      <$> o .:? "actions"
+      <*> o .:? "administration"
+      <*> o .:? "checks"
+      <*> o .:? "content_references"
+      <*> o .:? "contents"
+      <*> o .:? "deployments"
+      <*> o .:? "discussions"
+      <*> o .:? "emails"
+      <*> o .:? "environments"
+      <*> o .:? "issues"
+      <*> o .:? "keys"
+      <*> o .:? "members"
+      <*> o .:? "metadata"
+      <*> o .:? "organization_administration"
+      <*> o .:? "organization_hooks"
+      <*> o .:? "organization_packages"
+      <*> o .:? "organization_plan"
+      <*> o .:? "organization_projects"
+      <*> o .:? "organization_secrets"
+      <*> o .:? "organization_self_hosted_runners"
+      <*> o .:? "organization_user_blocking"
+      <*> o .:? "packages"
+      <*> o .:? "pages"
+      <*> o .:? "pull_requests"
+      <*> o .:? "repository_hooks"
+      <*> o .:? "repository_projects"
+      <*> o .:? "secret_scanning_alerts"
+      <*> o .:? "secrets"
+      <*> o .:? "security_events"
+      <*> o .:? "security_scanning_alert"
+      <*> o .:? "single_file"
+      <*> o .:? "statuses"
+      <*> o .:? "team_discussions"
+      <*> o .:? "vulnerability_alerts"
+      <*> o .:? "workflows"
 
 instance FromJSON HookCheckRun where
   parseJSON = withObject "HookCheckRun" $ \o -> HookCheckRun


### PR DESCRIPTION
**Issue reference:**
I didn't make an issue as this was a TODO.
The documentation for the app in the check suite is here  https://docs.github.com/en/webhooks/webhook-events-and-payloads#check_suite

**Submission Checklist:**
* [X] Have you followed the guidelines in our [Contributing](../../CONTRIBUTING.md) document (for example, is your tree a clean merge)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Does your submission build?
* [X] Does your submission pass tests?
* [X] Have you run lints on your code locally prior to submission?
* [ ] Have you updated *all* of the cabal/nix infrastructure?
* [ ] Is this a breaking change? Have you discussed this?

<!-- Please tag a maintainer if you don't get a response within a reasonable period of time -->
