### PR TITLE
Modified workflows so that they now trigger

### DIFF
--- a/.github/workflows/scan-code.yml
+++ b/.github/workflows/scan-code.yml
@@ -1,5 +1,6 @@
 on:
   push:
+    workflow_dispatch
   schedule:
     - cron: "0 ? * * 1"
 

--- a/.github/workflows/test-macos-latest.yml
+++ b/.github/workflows/test-macos-latest.yml
@@ -1,5 +1,6 @@
 on:
   push:
+    workflow_dispatch
   schedule:
     - cron: "0 ? * * 1"
 

--- a/.github/workflows/test-ubuntu-latest.yml
+++ b/.github/workflows/test-ubuntu-latest.yml
@@ -1,5 +1,6 @@
 on:
   push:
+    workflow_dispatch
   schedule:
     - cron: "0 ? * * 1"
 

--- a/.github/workflows/test-windows-latest.yml
+++ b/.github/workflows/test-windows-latest.yml
@@ -1,5 +1,6 @@
 on:
   push:
+    workflow_dispatch
   schedule:
     - cron: "0 ? * * 1"
 


### PR DESCRIPTION

**Issue reference:**
- Github Workflows couldn't be triggered because they were missing the line `on: workflow_dispatch`.

**Submission Checklist:**
* [x] Have you followed the guidelines in our [Contributing](../../CONTRIBUTING.md) document (for example, is your tree a clean merge)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Does your submission build?
* [x] Does your submission pass tests?
* [x] Have you run lints on your code locally prior to submission?
* [ ] Have you updated *all* of the cabal/nix infrastructure?
* [ ] Is this a breaking change? Have you discussed this?

<!-- Please tag a maintainer if you don't get a response within a reasonable period of time -->
