### PR TITLE
[#79]: Fixed workflows not triggering

### DIFF
--- a/.github/workflows/scan-code.yml
+++ b/.github/workflows/scan-code.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: 'Setup hlint'
         uses: rwe/actions-hlint-setup@v1

--- a/.github/workflows/scan-code.yml
+++ b/.github/workflows/scan-code.yml
@@ -1,5 +1,6 @@
 on:
   push:
+    workflow_dispatch
   schedule:
     - cron: "0 ? * * 1"
 

--- a/.github/workflows/scan-code.yml
+++ b/.github/workflows/scan-code.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    workflow_dispatch
+  workflow_dispatch:
   schedule:
     - cron: "0 ? * * 1"
 

--- a/.github/workflows/test-macos-latest.yml
+++ b/.github/workflows/test-macos-latest.yml
@@ -19,7 +19,7 @@ jobs:
           - latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: haskell/actions/setup@v2
         with:

--- a/.github/workflows/test-macos-latest.yml
+++ b/.github/workflows/test-macos-latest.yml
@@ -33,7 +33,7 @@ jobs:
           stack --skip-ghc-check test --flag github-webhooks:ci --haddock --no-haddock-deps
           stack sdist
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: github-webhooks-macos-${{ matrix.stack-yaml }}-${{ github.sha }}
           path: .stack-work/dist/

--- a/.github/workflows/test-macos-latest.yml
+++ b/.github/workflows/test-macos-latest.yml
@@ -1,5 +1,6 @@
 on:
   push:
+    workflow_dispatch
   schedule:
     - cron: "0 ? * * 1"
 

--- a/.github/workflows/test-macos-latest.yml
+++ b/.github/workflows/test-macos-latest.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    workflow_dispatch
+  workflow_dispatch:
   schedule:
     - cron: "0 ? * * 1"
 

--- a/.github/workflows/test-ubuntu-latest.yml
+++ b/.github/workflows/test-ubuntu-latest.yml
@@ -38,7 +38,7 @@ jobs:
             stack-version: 1.9
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: haskell/actions/setup@v2
         with:

--- a/.github/workflows/test-ubuntu-latest.yml
+++ b/.github/workflows/test-ubuntu-latest.yml
@@ -1,5 +1,6 @@
 on:
   push:
+    workflow_dispatch
   schedule:
     - cron: "0 ? * * 1"
 

--- a/.github/workflows/test-ubuntu-latest.yml
+++ b/.github/workflows/test-ubuntu-latest.yml
@@ -52,7 +52,7 @@ jobs:
           stack --skip-ghc-check test --flag github-webhooks:ci --haddock --no-haddock-deps
           stack sdist
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: github-webhooks-ubuntu-${{ matrix.stack-yaml }}-${{ github.sha }}
           path: .stack-work/dist/

--- a/.github/workflows/test-ubuntu-latest.yml
+++ b/.github/workflows/test-ubuntu-latest.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    workflow_dispatch
+  workflow_dispatch:
   schedule:
     - cron: "0 ? * * 1"
 

--- a/.github/workflows/test-windows-latest.yml
+++ b/.github/workflows/test-windows-latest.yml
@@ -19,7 +19,7 @@ jobs:
           - latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: haskell/actions/setup@v2
         with:

--- a/.github/workflows/test-windows-latest.yml
+++ b/.github/workflows/test-windows-latest.yml
@@ -33,7 +33,7 @@ jobs:
           stack --skip-ghc-check test --flag github-webhooks:ci --haddock --no-haddock-deps
           stack sdist
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: github-webhooks-windows-${{ matrix.stack-yaml }}-${{ github.sha }}
           path: .stack-work/dist/

--- a/.github/workflows/test-windows-latest.yml
+++ b/.github/workflows/test-windows-latest.yml
@@ -1,5 +1,6 @@
 on:
   push:
+    workflow_dispatch
   schedule:
     - cron: "0 ? * * 1"
 

--- a/.github/workflows/test-windows-latest.yml
+++ b/.github/workflows/test-windows-latest.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    workflow_dispatch
+  workflow_dispatch:
   schedule:
     - cron: "0 ? * * 1"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.18.0
+
+* A `draft` field was added to `HookPullRequest` (resolves #75)
+
 # 0.17.0
 
 * The sender of a push event was made optional for `PushEvent` (resolves #61)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,3 @@
-# 0.18.0
-
-* A `draft` field was added to `HookPullRequest` (resolves #75)
-
 # 0.17.0
 
 * The sender of a push event was made optional for `PushEvent` (resolves #61)


### PR DESCRIPTION
**Issue reference:**
In response to #79 

 - Added `workflow_dispatch:` to Github Workflows to give the ability to manually trigger a workflow rather than them being entirely manual or cron driven.
- Updated `actions/checkout` and `actions/upload-artifact` to version 4 of GitHub Actions since version 3 is now deprecated. 

**Submission Checklist:**
* [x] Have you followed the guidelines in our [Contributing](../../CONTRIBUTING.md) document (for example, is your tree a clean merge)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Does your submission build?
* [x] Does your submission pass tests?
* [ ] ~Have you run lints on your code locally prior to submission?~
* [ ] ~Have you updated *all* of the cabal/nix infrastructure?~
* [ ] ~Is this a breaking change? Have you discussed this?~

<!-- Please tag a maintainer if you don't get a response within a reasonable period of time -->
